### PR TITLE
[FEAT] Enhance revive beast functionality

### DIFF
--- a/client/src/components/screens/Home/HomeScreen.tsx
+++ b/client/src/components/screens/Home/HomeScreen.tsx
@@ -362,51 +362,66 @@ export const HomeScreen = ({ onNavigation }: HomeScreenProps) => {
               : "Your beloved companion needs your care to return to life"}
           </p>
 
-          {/* Botón */}
-          <div className="flex flex-col items-center space-y-2">
+          {/* Botones */}
+          <div className="flex flex-col items-center space-y-4 w-full max-w-xs">
+            {/* Botón Hatch New Beast */}
             <button
-              onClick={!currentBeastDisplay ? () => onNavigation("hatch") : handleReviveBeast}
-              disabled={isReviving || (!!currentBeastDisplay && (storePlayer?.total_gems || 0) < 20)}
-              className={`
-                ${!currentBeastDisplay
-                  ? "bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-400 hover:to-emerald-500"
-                  : (storePlayer?.total_gems || 0) >= 20
-                    ? "bg-gradient-to-r from-purple-500 to-purple-600 hover:from-purple-400 hover:to-purple-500"
-                    : "bg-gradient-to-r from-gray-400 to-gray-500 cursor-not-allowed"
-                }
+              onClick={() => onNavigation("hatch")}
+              className="
+                bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-400 hover:to-emerald-500
                 text-white px-8 py-4 rounded-xl font-bold transition-all transform
-                ${!isReviving && ((storePlayer?.total_gems || 0) >= 20 || !currentBeastDisplay) ? "hover:scale-105" : ""}
-                shadow-lg font-luckiest text-lg flex items-center gap-2 justify-center
-                ${isReviving ? "opacity-75 cursor-not-allowed" : ""}
-              `}
+                hover:scale-105 shadow-lg font-luckiest text-lg flex items-center gap-2 justify-center
+                w-full
+              "
             >
-              {isReviving ? (
-                <>
-                  <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
-                  Reviving...
-                </>
-              ) : !currentBeastDisplay ? (
-                <>🥚 Hatch New Beast</>
-              ) : (
-                <>
-                  <img src={gemIcon} alt="Gem" className="w-5 h-5" />
-                  20 ✨ Revive Beast
-                </>
-              )}
+              🥚 Hatch New Beast
             </button>
 
-            {/* Insufficient gems message */}
-            {currentBeastDisplay && (storePlayer?.total_gems || 0) < 20 && (
-              <p className="text-sm text-red-400 drop-shadow-md text-center">
-                Insufficient gems! You have {storePlayer?.total_gems || 0}/20 gems.
-                <br />
-                <span
-                  className="text-blue-300 underline cursor-pointer hover:text-blue-200"
-                  onClick={() => onNavigation("gemShop")}
+            {/* Botón Revive Beast - solo si el jugador tiene una bestia (viva o muerta) */}
+            {storePlayer && storePlayer.current_beast_id > 0 && (
+              <>
+                <button
+                  onClick={handleReviveBeast}
+                  disabled={isReviving || (storePlayer?.total_gems || 0) < 20}
+                  className={`
+                    ${(storePlayer?.total_gems || 0) >= 20
+                      ? "bg-gradient-to-r from-purple-400 to-purple-600 hover:from-purple-300 hover:to-purple-500"
+                      : "bg-gradient-to-r from-gray-400 to-gray-500 cursor-not-allowed"
+                    }
+                    text-white px-8 py-4 rounded-xl font-bold transition-all transform
+                    ${!isReviving && (storePlayer?.total_gems || 0) >= 20 ? "hover:scale-105" : ""}
+                    shadow-lg font-luckiest text-lg flex items-center gap-2 justify-center
+                    ${isReviving ? "opacity-75 cursor-not-allowed" : ""}
+                    w-full
+                  `}
                 >
-                  Get more gems →
-                </span>
-              </p>
+                  {isReviving ? (
+                    <>
+                      <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
+                      Reviving...
+                    </>
+                  ) : (
+                    <>
+                      <img src={gemIcon} alt="Gem" className="w-5 h-5" />
+                      20 ✨ Revive Beast
+                    </>
+                  )}
+                </button>
+
+                {/* Insufficient gems message */}
+                {(storePlayer?.total_gems || 0) < 20 && (
+                  <p className="text-sm text-red-400 drop-shadow-md text-center">
+                    Insufficient gems! You have {storePlayer?.total_gems || 0}/20 gems.
+                    <br />
+                    <span
+                      className="text-blue-300 underline cursor-pointer hover:text-blue-200"
+                      onClick={() => onNavigation("gemShop")}
+                    >
+                      Get more gems →
+                    </span>
+                  </p>
+                )}
+              </>
             )}
           </div>
         </div>

--- a/client/src/dojo/hooks/useReviveBeast.tsx
+++ b/client/src/dojo/hooks/useReviveBeast.tsx
@@ -51,8 +51,8 @@ export const useReviveBeast = (): UseReviveBeastReturn => {
       return { success: false, error: errorMsg };
     }
 
-    // Validation: Check if beast exists and is dead
-    if (!liveBeast) {
+    // Validation: Check if player has a beast (use current_beast_id since liveBeast is null when dead)
+    if (!storePlayer?.current_beast_id || storePlayer.current_beast_id === 0) {
       const errorMsg = 'No beast found to revive.';
       setError(errorMsg);
       toast.error(errorMsg);
@@ -174,9 +174,9 @@ export const useReviveBeast = (): UseReviveBeastReturn => {
           });
 
           // Log beast revival to Supabase (separate API call)
-          if (liveBeast) {
+          if (storePlayer?.current_beast_id) {
             systemLogsHelper.logBeastRevived(
-              liveBeast.beast_id,
+              storePlayer.current_beast_id,
               REVIVE_FEE_GEMS,
               txHash
             ).then(() => {


### PR DESCRIPTION
 Summary

  Fixed bug where dead beasts could not be revived. The UI now correctly
  displays both "Hatch New Beast" and "Revive Beast" buttons when a beast is
  dead, and the revive functionality works properly.

  Bug Description

  When a beast died, the home screen would only show the "Hatch New Beast"
  button without displaying the "Revive Beast" option. Additionally, the revive
  functionality was broken because:

  1. useLiveBeast hook only queries beasts with is_alive: true, so when a beast
  died, currentBeastDisplay and liveBeast became null
  2. The UI logic used currentBeastDisplay to determine whether to show the
  revive button, which was always null for dead beasts
  3. The useReviveBeast hook validated that liveBeast exists before executing,
  which always failed for dead beasts

  Fix Applied

  UI Changes (HomeScreen.tsx:337-426)

  - Modified button rendering logic to always show "Hatch New Beast" button when
   no live beast exists
  - Added conditional rendering for "Revive Beast" button based on
  storePlayer.current_beast_id > 0 instead of currentBeastDisplay
  - Updated "Revive Beast" button gradient from from-purple-500 to
  from-purple-400 for better visual consistency with the green gradient on
  "Hatch New Beast"
  - Both buttons now display correctly when a beast is dead

  Hook Changes (useReviveBeast.tsx:55-60, 177-187)

  - Changed validation logic from checking liveBeast to checking
  storePlayer.current_beast_id > 0
  - Updated beast revival logging to use storePlayer.current_beast_id instead of
   liveBeast.beast_id
  - This allows the revive function to work even when liveBeast is null (dead
  beast state)

  The fix leverages the fact that Player.current_beast_id persists even when a
  beast dies, providing a reliable indicator of whether a player has ever had a
  beast that can be revived.